### PR TITLE
removed old command

### DIFF
--- a/gateway.rst
+++ b/gateway.rst
@@ -431,7 +431,7 @@ ergänzt werden:
    #custom
    route-noexec
    up /etc/openvpn/mullvad_up.sh
-   up /etc/fastd/ffsh/iptables_ffsh.sh
+
 
 
 Mullvad hat an seinen Konfigurationen seit mehreren Sicherheitslücken


### PR DESCRIPTION
Irgendetwas funktioniert hier nicht. Mit jetziger Konfig funktioniert das gateway nicht wieder nachdem die VPN-Verbindung zurück gesetzt wurde. irgendwelche Regeln fallen da also raus wenn das tun0 verschwindet
